### PR TITLE
fix(player): implement shuffle button functionality

### DIFF
--- a/lib/screens/player/player_page.dart
+++ b/lib/screens/player/player_page.dart
@@ -543,12 +543,14 @@ class _PlayerPageState extends State<PlayerPage> {
             // Shuffle
             AdaptiveIconButton(
               onPressed: () {
-                // Toggle shuffle not implemented in UI, just icon for now or placeholder
+                mediaPlayer.setShuffleModeEnabled(!mediaPlayer.shuffleModeEnabled);
               },
               icon: Icon(
                 Icons.shuffle,
                 size: 24,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: mediaPlayer.shuffleModeEnabled
+                    ? Colors.white
+                    : Colors.white.withValues(alpha: 0.7),
               ),
             ),
             // Previous

--- a/lib/services/media_player.dart
+++ b/lib/services/media_player.dart
@@ -310,6 +310,13 @@ class MediaPlayer extends ChangeNotifier {
     GetIt.I<SettingsManager>().skipSilence = value;
   }
 
+  Future<void> setShuffleModeEnabled(bool value) async {
+    if (value) {
+      await _player.shuffle();
+    }
+    await _player.setShuffleModeEnabled(value);
+  }
+
   Future<AudioSource> _getAudioSource(Map<String, dynamic> song) async {
     MediaItem tag = MediaItem(
       id: song['videoId'],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -785,18 +785,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_new_shapes:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1270,10 +1270,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   text_scroll:
     dependency: "direct main"
     description:
@@ -1512,7 +1512,7 @@ packages:
       path: "."
       ref: HEAD
       resolved-ref: "78d716afa9bccd117020a1983361ebf4fffaaf28"
-      url: "https://github.com/iad1tya/youtube_explode_dart"
+      url: "https://github.com/EchoMusicApp/youtube_explode_dart"
     source: git
     version: "3.0.5"
 sdks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   hive_flutter: ^1.1.0
   youtube_explode_dart:
     git:
-      url: https://github.com/iad1tya/youtube_explode_dart
+      url: https://github.com/EchoMusicApp/youtube_explode_dart
   expandable_page_view: ^1.0.17
   get_it: ^8.0.3
   cached_network_image: ^3.3.1


### PR DESCRIPTION
Closes #1.

This PR implements the missing shuffle toggling capability in the media player backend and hooks it up to the player page UI button, matching the design of the repeat mode toggle button.

Also resolves a compilation blocker by updating the obsolete youtube_explode_dart git dependency source to the active EchoMusicApp fork.