### PR TITLE
fix(player): implement shuffle button state & custom playlist shuffling on Desktop

### DIFF
--- a/lib/screens/player/player_page.dart
+++ b/lib/screens/player/player_page.dart
@@ -543,12 +543,14 @@ class _PlayerPageState extends State<PlayerPage> {
             // Shuffle
             AdaptiveIconButton(
               onPressed: () {
-                // Toggle shuffle not implemented in UI, just icon for now or placeholder
+                mediaPlayer.setShuffleModeEnabled(!mediaPlayer.shuffleModeEnabled);
               },
               icon: Icon(
                 Icons.shuffle,
                 size: 24,
-                color: Colors.white.withValues(alpha: 0.7),
+                color: mediaPlayer.shuffleModeEnabled
+                    ? Colors.white
+                    : Colors.white.withValues(alpha: 0.7),
               ),
             ),
             // Previous

--- a/lib/services/media_player.dart
+++ b/lib/services/media_player.dart
@@ -20,6 +20,7 @@ class MediaPlayer extends ChangeNotifier {
   AndroidEqualizerParameters? _equalizerParams;
 
   List<IndexedAudioSource> _songList = [];
+  List<Map<String, dynamic>> _originalPlaylist = [];
   final ValueNotifier<MediaItem?> _currentSongNotifier = ValueNotifier(null);
   final ValueNotifier<int?> _currentIndex = ValueNotifier(null);
   final ValueNotifier<ButtonState> _buttonState =
@@ -267,12 +268,14 @@ class MediaPlayer extends ChangeNotifier {
   }
 
   void _listenToShuffle() {
-    _player.shuffleModeEnabledStream.listen((data) {
-      if (_shuffleModeEnabled != data) {
-        _shuffleModeEnabled = data;
-        notifyListeners();
-      }
-    });
+    if (Platform.isAndroid || Platform.isIOS) {
+      _player.shuffleModeEnabledStream.listen((data) {
+        if (_shuffleModeEnabled != data) {
+          _shuffleModeEnabled = data;
+          notifyListeners();
+        }
+      });
+    }
   }
 
   void _listenToChangesInSong() {
@@ -316,10 +319,18 @@ class MediaPlayer extends ChangeNotifier {
     _shuffleModeEnabled = value;
     notifyListeners();
     try {
-      if (value) {
-        await _player.shuffle();
+      if (Platform.isAndroid || Platform.isIOS) {
+        if (value) {
+          await _player.shuffle();
+        }
+        await _player.setShuffleModeEnabled(value);
+      } else {
+        if (value) {
+          await _shuffleRemainingQueue();
+        } else {
+          await _restoreOriginalQueueOrder();
+        }
       }
-      await _player.setShuffleModeEnabled(value);
     } catch (e) {
       print("Error setting shuffle mode: $e");
     }
@@ -365,6 +376,8 @@ class MediaPlayer extends ChangeNotifier {
     // Generate a new request ID
     final int requestId = DateTime.now().millisecondsSinceEpoch;
     _lastPlayRequestId = requestId;
+
+    _originalPlaylist = [song];
 
     // OPTIMISTIC UPDATE: Show miniplayer immediately with loading state
     MediaItem tempTag = MediaItem(
@@ -412,8 +425,18 @@ class MediaPlayer extends ChangeNotifier {
   }
 
   Future<void> playNext(Map<String, dynamic> mediaItem) async {
+    final currentSong = _currentSongNotifier.value;
+    int insertIndexOrig = _originalPlaylist.length;
+    if (currentSong != null) {
+      final origIdx = _originalPlaylist.indexWhere((song) => song['videoId'] == currentSong.id);
+      if (origIdx != -1) {
+        insertIndexOrig = origIdx + 1;
+      }
+    }
+
     // Case 1: A single video/song
     if (mediaItem['videoId'] != null) {
+      _originalPlaylist.insert(insertIndexOrig, mediaItem);
       final audioSource = await _getAudioSource(mediaItem);
 
       // Determine insertion position
@@ -432,6 +455,8 @@ class MediaPlayer extends ChangeNotifier {
       // Case 2: Custom or Downloaded Playlist
     } else if (mediaItem['songs'] != null) {
       List songs = mediaItem['songs'];
+      final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+      _originalPlaylist.insertAll(insertIndexOrig, songMaps);
       await _addSongListToQueue(songs, isNext: true);
 
       // Case 3: Online Playlist
@@ -440,6 +465,8 @@ class MediaPlayer extends ChangeNotifier {
           ? await GetIt.I<YTMusic>()
               .getNextSongList(playlistId: mediaItem['playlistId'])
           : await GetIt.I<YTMusic>().getPlaylistSongs(mediaItem['playlistId']);
+      final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+      _originalPlaylist.insertAll(insertIndexOrig, songMaps);
       await _addSongListToQueue(songs, isNext: true);
     }
   }
@@ -448,6 +475,7 @@ class MediaPlayer extends ChangeNotifier {
     if (songs.isEmpty) return;
 
     autoFetching = true;
+    _originalPlaylist = songs.map((s) => Map<String, dynamic>.from(s)).toList();
 
     _buttonState.value = ButtonState.loading;
     notifyListeners();
@@ -485,14 +513,18 @@ class MediaPlayer extends ChangeNotifier {
   Future<void> _addRemainingToPlaylist(List songs, int playedIndex) async {
     try {
       int added = 0;
+      final remaining = <Map<String, dynamic>>[];
+      for (int i = playedIndex + 1; i < songs.length; i++) {
+        remaining.add(Map<String, dynamic>.from(songs[i]));
+      }
 
-      // Add songs after the played index (next songs first)
-      for (int i = playedIndex + 1;
-          i < songs.length;
-          i++) {
+      if (_shuffleModeEnabled) {
+        remaining.shuffle();
+      }
+
+      for (var song in remaining) {
         try {
-          final source =
-              await _getAudioSource(Map<String, dynamic>.from(songs[i]));
+          final source = await _getAudioSource(song);
           await _player.addAudioSource(source);
           added++;
         } catch (e) {
@@ -507,11 +539,14 @@ class MediaPlayer extends ChangeNotifier {
   Future<void> addToQueue(Map<String, dynamic> mediaItem) async {
     // Case 1: A single video/song
     if (mediaItem['videoId'] != null) {
+      _originalPlaylist.add(mediaItem);
       await _player.addAudioSource(await _getAudioSource(mediaItem));
 
       // Case 2: Custom or Downloaded Playlist
     } else if (mediaItem['songs'] != null) {
       List songs = mediaItem['songs'];
+      final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+      _originalPlaylist.addAll(songMaps);
       await _addSongListToQueue(songs, isNext: false);
 
       // Case 3: Online Playlist
@@ -520,12 +555,15 @@ class MediaPlayer extends ChangeNotifier {
           ? await GetIt.I<YTMusic>()
               .getNextSongList(playlistId: mediaItem['playlistId'])
           : await GetIt.I<YTMusic>().getPlaylistSongs(mediaItem['playlistId']);
+      final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+      _originalPlaylist.addAll(songMaps);
       await _addSongListToQueue(songs, isNext: false);
     }
   }
 
   Future<void> startRelated(Map<String, dynamic> song,
       {bool radio = false, bool shuffle = false, bool isArtist = false}) async {
+    _originalPlaylist = [];
     await _player.clearAudioSources();
     if (!isArtist) {
       await addToQueue(song);
@@ -536,11 +574,14 @@ class MediaPlayer extends ChangeNotifier {
         radio: radio,
         shuffle: shuffle);
     if (songs.isNotEmpty) songs.removeAt(0);
+    final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+    _originalPlaylist.addAll(songMaps);
     await _addSongListToQueue(songs, isNext: false);
     await _player.play();
   }
 
   Future<void> startPlaylistSongs(Map endpoint) async {
+    _originalPlaylist = [];
     await _player.clearAudioSources();
     List songs = await GetIt.I<YTMusic>().getNextSongList(
         playlistId: endpoint['playlistId'], params: endpoint['params']);
@@ -549,6 +590,8 @@ class MediaPlayer extends ChangeNotifier {
       // if API returned a placeholder, convert or handle accordingly
     }
 
+    final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+    _originalPlaylist.addAll(songMaps);
     await _addSongListToQueue(songs);
     await _player.play();
   }
@@ -565,10 +608,14 @@ class MediaPlayer extends ChangeNotifier {
   Future<void> _addSongListToQueue(List songs, {bool isNext = false}) async {
     if (songs.isEmpty) return;
 
+    final songMaps = songs.map((s) => Map<String, dynamic>.from(s)).toList();
+    if (_shuffleModeEnabled) {
+      songMaps.shuffle();
+    }
+
     // Convert your song objects into AudioSources
-    final newSources = await Future.wait(songs.map((song) async {
-      final mapSong = Map<String, dynamic>.from(song);
-      return await _getAudioSource(mapSong);
+    final newSources = await Future.wait(songMaps.map((song) async {
+      return await _getAudioSource(song);
     }));
 
     // Current queue length
@@ -595,6 +642,8 @@ class MediaPlayer extends ChangeNotifier {
         List nextSongs = await GetIt.I<YTMusic>()
             .getNextSongList(videoId: player.sequence[index].tag.id);
         if (nextSongs.isNotEmpty) nextSongs.removeAt(0);
+        final songMaps = nextSongs.map((s) => Map<String, dynamic>.from(s)).toList();
+        _originalPlaylist.addAll(songMaps);
         await _addSongListToQueue(nextSongs);
         autoFetching = false;
       }
@@ -619,6 +668,44 @@ class MediaPlayer extends ChangeNotifier {
     _timerDuration.value = null;
     _timer?.cancel();
     notifyListeners();
+  }
+
+  Future<void> _shuffleRemainingQueue() async {
+    final currentIndex = _player.currentIndex;
+    if (currentIndex == null) return;
+    final totalSources = _player.sequence?.length ?? 0;
+    if (currentIndex + 1 >= totalSources) return;
+
+    final List<AudioSource> remainingSources = [];
+    for (int i = currentIndex + 1; i < totalSources; i++) {
+      remainingSources.add(_player.audioSources[i]);
+    }
+
+    await _player.removeAudioSourceRange(currentIndex + 1, totalSources);
+    remainingSources.shuffle();
+    await _player.addAudioSources(remainingSources);
+  }
+
+  Future<void> _restoreOriginalQueueOrder() async {
+    final currentSong = _currentSongNotifier.value;
+    if (currentSong == null) return;
+
+    final origIndex = _originalPlaylist.indexWhere((song) => song['videoId'] == currentSong.id);
+    if (origIndex == -1) return;
+
+    final remainingSongs = _originalPlaylist.sublist(origIndex + 1);
+
+    final currentIndex = _player.currentIndex ?? 0;
+    final totalSources = _player.sequence?.length ?? 0;
+
+    if (currentIndex + 1 < totalSources) {
+      await _player.removeAudioSourceRange(currentIndex + 1, totalSources);
+    }
+
+    if (remainingSongs.isNotEmpty) {
+      final newSources = await Future.wait(remainingSongs.map((song) => _getAudioSource(song)));
+      await _player.addAudioSources(newSources);
+    }
   }
 }
 

--- a/lib/services/media_player.dart
+++ b/lib/services/media_player.dart
@@ -268,8 +268,10 @@ class MediaPlayer extends ChangeNotifier {
 
   void _listenToShuffle() {
     _player.shuffleModeEnabledStream.listen((data) {
-      _shuffleModeEnabled = data;
-      notifyListeners();
+      if (_shuffleModeEnabled != data) {
+        _shuffleModeEnabled = data;
+        notifyListeners();
+      }
     });
   }
 
@@ -308,6 +310,19 @@ class MediaPlayer extends ChangeNotifier {
   Future<void> skipSilence(bool value) async {
     await _player.setSkipSilenceEnabled(value);
     GetIt.I<SettingsManager>().skipSilence = value;
+  }
+
+  Future<void> setShuffleModeEnabled(bool value) async {
+    _shuffleModeEnabled = value;
+    notifyListeners();
+    try {
+      if (value) {
+        await _player.shuffle();
+      }
+      await _player.setShuffleModeEnabled(value);
+    } catch (e) {
+      print("Error setting shuffle mode: $e");
+    }
   }
 
   Future<AudioSource> _getAudioSource(Map<String, dynamic> song) async {

--- a/lib/services/media_player.dart
+++ b/lib/services/media_player.dart
@@ -670,41 +670,118 @@ class MediaPlayer extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _shuffleRemainingQueue() async {
-    final currentIndex = _player.currentIndex;
-    if (currentIndex == null) return;
-    final totalSources = _player.sequence?.length ?? 0;
-    if (currentIndex + 1 >= totalSources) return;
-
-    final List<AudioSource> remainingSources = [];
-    for (int i = currentIndex + 1; i < totalSources; i++) {
-      remainingSources.add(_player.audioSources[i]);
+  Future<AudioSource> _cloneSource(AudioSource source, Map<String, dynamic> song) async {
+    if (source is UriAudioSource) {
+      return AudioSource.uri(source.uri, tag: source.tag);
     }
+    return await _getAudioSource(song);
+  }
 
-    await _player.removeAudioSourceRange(currentIndex + 1, totalSources);
-    remainingSources.shuffle();
-    await _player.addAudioSources(remainingSources);
+  Future<void> _shuffleRemainingQueue() async {
+    try {
+      final currentSong = _currentSongNotifier.value;
+      if (currentSong == null) return;
+      final currentIndex = _player.currentIndex;
+      if (currentIndex == null) return;
+      final currentPosition = _player.position;
+
+      final allSources = List<IndexedAudioSource>.from(_player.sequence ?? []);
+      if (allSources.isEmpty || currentIndex + 1 >= allSources.length) return;
+
+      final beforeSources = allSources.sublist(0, currentIndex);
+      final remainingSources = allSources.sublist(currentIndex + 1);
+
+      // Create new fresh AudioSource objects for beforeSources
+      final List<AudioSource> newBeforeSources = [];
+      for (int i = 0; i < beforeSources.length; i++) {
+        final src = beforeSources[i];
+        final song = _originalPlaylist.firstWhere(
+          (s) => s['videoId'] == (src.tag as MediaItem).id,
+          orElse: () => <String, dynamic>{},
+        );
+        newBeforeSources.add(await _cloneSource(src, song));
+      }
+
+      // Create new fresh AudioSource objects for remainingSources
+      final List<AudioSource> newRemainingSources = [];
+      for (int i = 0; i < remainingSources.length; i++) {
+        final src = remainingSources[i];
+        final song = _originalPlaylist.firstWhere(
+          (s) => s['videoId'] == (src.tag as MediaItem).id,
+          orElse: () => <String, dynamic>{},
+        );
+        newRemainingSources.add(await _cloneSource(src, song));
+      }
+
+      // Shuffle the remaining ones
+      newRemainingSources.shuffle();
+
+      // Current source cloned
+      final currentSrc = allSources[currentIndex];
+      final currentSongMap = _originalPlaylist.firstWhere(
+        (s) => s['videoId'] == (currentSrc.tag as MediaItem).id,
+        orElse: () => <String, dynamic>{},
+      );
+      final newCurrentSource = await _cloneSource(currentSrc, currentSongMap);
+
+      final newSources = [...newBeforeSources, newCurrentSource, ...newRemainingSources];
+
+      await _player.setAudioSource(
+        ConcatenatingAudioSource(children: newSources),
+        initialIndex: currentIndex,
+        initialPosition: currentPosition,
+      );
+    } catch (e) {
+      print("Error shuffling remaining queue: $e");
+    }
   }
 
   Future<void> _restoreOriginalQueueOrder() async {
-    final currentSong = _currentSongNotifier.value;
-    if (currentSong == null) return;
+    try {
+      final currentSong = _currentSongNotifier.value;
+      if (currentSong == null) return;
+      final currentPosition = _player.position;
 
-    final origIndex = _originalPlaylist.indexWhere((song) => song['videoId'] == currentSong.id);
-    if (origIndex == -1) return;
+      final allSources = List<IndexedAudioSource>.from(_player.sequence ?? []);
 
-    final remainingSongs = _originalPlaylist.sublist(origIndex + 1);
+      final sourceMap = <String, IndexedAudioSource>{};
+      for (var source in allSources) {
+        final tag = source.tag;
+        if (tag is MediaItem) {
+          sourceMap[tag.id] = source;
+        }
+      }
 
-    final currentIndex = _player.currentIndex ?? 0;
-    final totalSources = _player.sequence?.length ?? 0;
+      final usedSources = <IndexedAudioSource>{};
+      final List<AudioSource> originalSources = [];
+      for (var song in _originalPlaylist) {
+        final videoId = song['videoId'];
+        final source = sourceMap[videoId];
+        if (source != null && !usedSources.contains(source)) {
+          originalSources.add(await _cloneSource(source, song));
+          usedSources.add(source);
+        } else {
+          final newSource = await _getAudioSource(song);
+          originalSources.add(newSource);
+        }
+      }
 
-    if (currentIndex + 1 < totalSources) {
-      await _player.removeAudioSourceRange(currentIndex + 1, totalSources);
-    }
+      final origIndex = originalSources.indexWhere((source) {
+        if (source is IndexedAudioSource) {
+          final tag = source.tag;
+          return tag is MediaItem && tag.id == currentSong.id;
+        }
+        return false;
+      });
+      if (origIndex == -1) return;
 
-    if (remainingSongs.isNotEmpty) {
-      final newSources = await Future.wait(remainingSongs.map((song) => _getAudioSource(song)));
-      await _player.addAudioSources(newSources);
+      await _player.setAudioSource(
+        ConcatenatingAudioSource(children: originalSources),
+        initialIndex: origIndex,
+        initialPosition: currentPosition,
+      );
+    } catch (e) {
+      print("Error restoring original queue order: $e");
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -785,18 +785,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_new_shapes:
     dependency: transitive
     description:
@@ -849,10 +849,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1270,10 +1270,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   text_scroll:
     dependency: "direct main"
     description:
@@ -1512,7 +1512,7 @@ packages:
       path: "."
       ref: HEAD
       resolved-ref: "78d716afa9bccd117020a1983361ebf4fffaaf28"
-      url: "https://github.com/iad1tya/youtube_explode_dart"
+      url: "https://github.com/EchoMusicApp/youtube_explode_dart"
     source: git
     version: "3.0.5"
 sdks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   hive_flutter: ^1.1.0
   youtube_explode_dart:
     git:
-      url: https://github.com/iad1tya/youtube_explode_dart
+      url: https://github.com/EchoMusicApp/youtube_explode_dart
   expandable_page_view: ^1.0.17
   get_it: ^8.0.3
   cached_network_image: ^3.3.1


### PR DESCRIPTION
Closes #1

This PR fixes the shuffle button bug on Desktop (Windows/Linux/macOS) by implementing custom in-place playlist shuffling. This bypasses the \just_audio_media_kit\ limitation where the player backend ignores the shuffle mode state, causing playback sequence desynchronization.

### Changes:
1. Track \_originalPlaylist\ in MediaPlayer state to support toggling shuffle mode ON and OFF.
2. Rearrange the player's active concatenating audio source sequence when shuffle is toggled ON (shuffling remaining songs) or OFF (restoring original remaining sequence).
3. Dynamically highlight the shuffle button in the UI based on shuffle state.
4. Resolve repository dependency source for \youtube_explode_dart\ in \pubspec.yaml\.

Tested and verified compiled on Windows.